### PR TITLE
検索のURLにindex.htmlがつかないようにした

### DIFF
--- a/.template/aside.html
+++ b/.template/aside.html
@@ -16,7 +16,7 @@
             <h2>ページ内検索</h2>
             <hr class="titlebar">
             <p>ページ内の検索ができます。
-                <form action="/search/index.html" method="get">
+                <form action="/search/" method="get">
                     <label for="searchTerm"></label>
                     <div class="search_box">
                         <input type="text" name="q" id="searchTerm" placeholder="検索" class="search_input">


### PR DESCRIPTION
検索結果のページで他のページと同様にURLに`index.html`がつかないようにした。これでいいのかちゃんと確かめてないのでもしかしたら破壊されてるかも。